### PR TITLE
Write version.rs to OUT_DIR instead of src

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ extern crate semver;
 
 use std::fs::File;
 use std::io::Write;
+use std::{env, path};
 
 use semver::Identifier;
 use rustc_version::{version_meta, Channel};
@@ -24,7 +25,9 @@ fn identifiers_to_source(ids: &Vec<Identifier>) -> String {
 }
 
 fn main() {
-    let mut f = File::create("src/version.rs").unwrap();
+    let mut path = path::PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    path.push("version.rs");
+    let mut f = File::create(&path).unwrap();
 
     write!(f, "
             use rustc_version::{{Channel, VersionMeta}};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ extern crate semver;
 
 use semver::{Version, VersionReq};
 
-mod version;
+mod version {
+    include!(concat!(env!("OUT_DIR"), "/version.rs"));
+}
 pub use version::version_meta;
 
 /// Returns the `rustc` SemVer version.


### PR DESCRIPTION
This breaks compilation on docs.rs (e.g. [here](https://docs.rs/crate/rustpython-vm/0.1.2/builds/264114), rust-lang/docs.rs#811), so it would be great if this could get merged.