### PR TITLE
Reexport all semver and rustc_version types visible through the public API

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,10 +29,6 @@ fn main() {
     path.push("version.rs");
     let mut f = File::create(&path).unwrap();
 
-    write!(f, "
-            use rustc_version::{{Channel, VersionMeta}};
-            use semver;
-            ").unwrap();
     let version = version_meta().expect("Failed to read rustc version.");
 
     write!(f, "
@@ -40,7 +36,7 @@ fn main() {
             /// like the git short hash and build date.
             pub fn version_meta() -> VersionMeta {{
                 VersionMeta {{
-                    semver: semver::Version {{
+                    semver: Version {{
                         major: {major},
                         minor: {minor},
                         patch: {patch},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,12 @@
 
 extern crate rustc_version;
 extern crate semver;
+use semver::VersionReq;
+pub use semver::Identifier;
 
-use semver::{Version, VersionReq};
-
+pub use rustc_version::{Version, VersionMeta, Channel};
 mod version {
+    use super::*;
     include!(concat!(env!("OUT_DIR"), "/version.rs"));
 }
 pub use version::version_meta;


### PR DESCRIPTION
Currently a user of this library might have to explicitly specify `semver` and/or `rust_version` in their `Cargo.toml` (and even in the correct version) to work with the types available in the public API of this library.

This pull request reexports all of these types, so that only specifying `rustc_version_runtime` in the `Cargo.toml` should be enough in all cases.