### PR TITLE
Upgrade dependencies (fixes issue #7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_version_runtime"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ["version", "rustc"]
 build = "build.rs"
 
 [dependencies]
-rustc_version = "0.2.3"
-semver = "0.9"
+rustc_version = "0.4.0"
+semver = "1.0"
 
 [build-dependencies]
-rustc_version = "0.2.3"
-semver = "0.9"
+rustc_version = "0.4.0"
+semver = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -5,24 +5,7 @@ use std::fs::File;
 use std::io::Write;
 use std::{env, path};
 
-use semver::Identifier;
 use rustc_version::{version_meta, Channel};
-
-fn identifier_to_source(id: &Identifier) -> String {
-    match *id {
-        Identifier::Numeric(ref n) => format!("semver::Identifier::Numeric({})", n),
-        Identifier::AlphaNumeric(ref n) => format!("semver::Identifier::AlphaNumeric({:?}.to_owned())", n),
-    }
-}
-
-fn identifiers_to_source(ids: &Vec<Identifier>) -> String {
-    let mut r = "vec![".as_bytes().to_vec();
-    for id in ids {
-        write!(r, "{}, ", identifier_to_source(id)).unwrap();
-    }
-    write!(r, "]").unwrap();
-    String::from_utf8(r).unwrap()
-}
 
 fn main() {
     let mut path = path::PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -31,7 +14,17 @@ fn main() {
 
     let version = version_meta().expect("Failed to read rustc version.");
 
-    write!(f, "
+    let llvm_version = match version.llvm_version {
+        Some(ver) => format!(
+            "Some(LlvmVersion{{ major: {}, minor: {} }})",
+            ver.major, ver.minor
+        ),
+        None => "None".to_owned(),
+    };
+
+    write!(
+        f,
+        "
             /// Returns the `rustc` SemVer version and additional metadata
             /// like the git short hash and build date.
             pub fn version_meta() -> VersionMeta {{
@@ -40,8 +33,8 @@ fn main() {
                         major: {major},
                         minor: {minor},
                         patch: {patch},
-                        pre: {pre},
-                        build: {build},
+                        pre: Prerelease::new(\"{pre}\").unwrap(),
+                        build: BuildMetadata::new(\"{build}\").unwrap(),
                     }},
                     host: \"{host}\".to_owned(),
                     short_version_string: \"{short_version_string}\".to_owned(),
@@ -49,24 +42,36 @@ fn main() {
                     commit_date: {commit_date},
                     build_date: {build_date},
                     channel: Channel::{channel},
+                    llvm_version: {llvm_version},
                 }}
             }}
             ",
-            major = version.semver.major,
-            minor = version.semver.minor,
-            patch = version.semver.patch,
-            pre = identifiers_to_source(&version.semver.pre),
-            build = identifiers_to_source(&version.semver.build),
-            commit_hash = version.commit_hash.map(|h| format!("Some(\"{}\".to_owned())", h)).unwrap_or("None".to_owned()),
-            commit_date = version.commit_date.map(|h| format!("Some(\"{}\".to_owned())", h)).unwrap_or("None".to_owned()),
-            build_date = version.build_date.map(|h| format!("Some(\"{}\".to_owned())", h)).unwrap_or("None".to_owned()),
-            host = version.host,
-            short_version_string = version.short_version_string,
-            channel = match version.channel {
-                Channel::Dev => "Dev",
-                Channel::Nightly => "Nightly",
-                Channel::Beta => "Beta",
-                Channel::Stable => "Stable",
-            }
-            ).unwrap();
+        major = version.semver.major,
+        minor = version.semver.minor,
+        patch = version.semver.patch,
+        pre = version.semver.pre,
+        build = version.semver.build,
+        commit_hash = version
+            .commit_hash
+            .map(|h| format!("Some(\"{}\".to_owned())", h))
+            .unwrap_or("None".to_owned()),
+        commit_date = version
+            .commit_date
+            .map(|h| format!("Some(\"{}\".to_owned())", h))
+            .unwrap_or("None".to_owned()),
+        build_date = version
+            .build_date
+            .map(|h| format!("Some(\"{}\".to_owned())", h))
+            .unwrap_or("None".to_owned()),
+        host = version.host,
+        short_version_string = version.short_version_string,
+        channel = match version.channel {
+            Channel::Dev => "Dev",
+            Channel::Nightly => "Nightly",
+            Channel::Beta => "Beta",
+            Channel::Stable => "Stable",
+        },
+        llvm_version = llvm_version,
+    )
+    .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 
 extern crate rustc_version;
 extern crate semver;
-use semver::VersionReq;
-pub use semver::Identifier;
+use rustc_version::LlvmVersion;
+use semver::{BuildMetadata, Prerelease, VersionReq};
 
-pub use rustc_version::{Version, VersionMeta, Channel};
+pub use rustc_version::{Channel, Version, VersionMeta};
 mod version {
     use super::*;
     include!(concat!(env!("OUT_DIR"), "/version.rs"));
@@ -40,7 +40,7 @@ pub fn version_matches(req: &str) -> bool {
     // I believe users of this crate would expect 1.31.0-nightly to be greater than 1.30 and
     // equal to 1.31.0. This might not be the case, but I cannot see why.
     let mut v = version();
-    v.pre = vec![];
+    v.pre = Prerelease::new("").unwrap();
     VersionReq::parse(req).unwrap().matches(&v)
 }
 


### PR DESCRIPTION
This upgrades to the latest versions of the dependencies.

I also bumped the version number, as this will be a semver incompatible release (since the `VersionMeta` structure of rustc_version has changed in a semver incompatible way).